### PR TITLE
Added support for linking notes 

### DIFF
--- a/lib/argown-core.js
+++ b/lib/argown-core.js
@@ -714,6 +714,7 @@ var TokenNames;
     TokenNames["COMMENT"] = "Comment";
     TokenNames["TAG"] = "Tag";
     TokenNames["LINK"] = "Link";
+    TokenNames["OBSIDIAN_LINK"] = "ObsidianLink";
     TokenNames["ESCAPED_CHAR"] = "EscapedChar";
     TokenNames["SPECIAL_CHAR"] = "SpecialChar";
     TokenNames["SPACES"] = "Spaces";
@@ -1424,6 +1425,12 @@ exports.Link = createToken({
     label: "[Title](Url) (Link)"
 });
 exports.tokenList.push(exports.Link);
+exports.ObsidianLink = createToken({
+    name: TokenNames_1.TokenNames.OBSIDIAN_LINK,
+    pattern: /\[\[[^\]\[]+?\]\][ \t]?/,
+    label: "[[Note]] (ObsidianLink)"
+    })
+exports.tokenList.push(exports.ObsidianLink);
 exports.Tag = createToken({
     name: TokenNames_1.TokenNames.TAG,
     pattern: /#(?:\([^\)]+\)|[a-zA-z0-9-\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+)[ \t]?/,
@@ -1502,6 +1509,7 @@ const lexerConfig = {
             exports.AsteriskItalicStart,
             exports.UnderscoreItalicStart,
             exports.Link,
+            exports.ObsidianLink,
             exports.Tag,
             exports.StatementDefinition,
             exports.StatementReference,
@@ -1578,6 +1586,7 @@ var RangeType;
     RangeType["BOLD"] = "bold";
     RangeType["ITALIC"] = "italic";
     RangeType["LINK"] = "link";
+    RangeType["OBSIDIAN_LINK"] = "obsidian-link";
     RangeType["TAG"] = "tag";
     RangeType["STATEMENT_MENTION"] = "statement-mention";
     RangeType["ARGUMENT_MENTION"] = "argument-mention";
@@ -2322,6 +2331,9 @@ class ArgdownParser extends chevrotain_1.EmbeddedActionsParser {
                         },
                         {
                             ALT: () => this.CONSUME(lexer.Link)
+                        },
+                        {
+                            ALT: () => this.CONSUME(lexer.ObsidianLink)
                         },
                         {
                             ALT: () => this.SUBRULE(this.bold)
@@ -3130,7 +3142,7 @@ class DotExportPlugin {
                 dot += `  ${node.id} [label=${groupLabel}, shape="box", margin="${groupSettings.margin}", style="filled", penwidth="0" fillcolor="${groupColor}", fontcolor="${node.fontColor}",  type="${node.type}"];\n`;
             }
             else {
-                dot += `\nsubgraph ${dotGroupId} {\n  label = ${groupLabel};\n  color = "${groupColor}";\n  margin="${groupSettings.margin}" style = filled;\n`;
+                dot += `\nsubgraph ${dotGroupId} {\n label = ${groupLabel};\n  color = "${groupColor}";\n  margin="${groupSettings.margin}" style = filled;\n`;
                 let labelloc = "t";
                 if (settings.graphVizSettings &&
                     settings.graphVizSettings.rankdir == "BT") {
@@ -4233,6 +4245,11 @@ class HtmlExportPlugin {
                 }
                 response.html += `<a href="${linkUrl}">${linkText}</a>${token.trailingWhitespace}`;
             },
+            [TokenNames_1.TokenNames.OBSIDIAN_LINK]: (request, response, token) => {
+                let noteText = token.text;
+                response.html += `<a data-href="${noteText}" href="${noteText}" class="internal-link" target="_blank" rel="noopener">${noteText}</a>`;
+               // <a data-href="testing-links" href="testing-links" class="internal-link" target="_blank" rel="noopener">testing-links</a>
+            },
             [TokenNames_1.TokenNames.TAG]: (_request, response, node) => {
                 const token = node;
                 if (token.text) {
@@ -5231,6 +5248,7 @@ class ModelPlugin {
         const argumentDefinitionPattern = /\<(.+)\>\:/;
         const argumentMentionPattern = /\@\<(.+)\>(\s?)/;
         const linkPattern = /\[(.+)\]\((.+)\)/;
+        const obsidianLinkPattern = /\[\[(.+)\]\]/;
         const tagPattern = /#(?:\(([^\)]+)\)|([a-zA-z0-9-\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+))/;
         let uniqueTitleCounter = 0;
         function getUniqueTitle() {
@@ -5461,6 +5479,30 @@ class ModelPlugin {
                     target.ranges = [];
                 }
                 target.ranges.push(linkRange);
+            },
+            [TokenNames_1.TokenNames.OBSIDIAN_LINK]: (_request, _response, token) => {
+                const target = currentHeading ? currentHeading : currentStatement;
+                if (!target) {
+                    return;
+                }
+                let match = obsidianLinkPattern.exec(token.image);
+                if (!match || match.length < 2) {
+                    throw new ArgdownPluginError_1.ArgdownPluginError(this.name, "invalid-link", "Could not match obsidian link.");
+                }
+                token.text = match[1];
+                const oldText = target.text || "";
+                const newText = oldText + token.text;
+                target.text = newText;
+                let obsidianLinkRange = {
+                    type: model_1.RangeType.OBSIDIAN_LINK,
+                    start: oldText.length,
+                    stop: newText.length - 1
+                };
+                obsidianLinkRange.text = token.text;
+                if (!target.ranges) {
+                    target.ranges = [];
+                }
+                target.ranges.push(obsidianLinkRange);
             },
             [TokenNames_1.TokenNames.TAG]: (request, response, token) => {
                 const target = currentHeading || currentStatement;
@@ -15167,7 +15209,6 @@ function firstCharOptimizedIndices(ast, result, ignoreCase) {
         default:
             throw Error("non exhaustive match!");
     }
-    // console.log(Object.keys(result).length)
     return utils_1.values(result);
 }
 exports.firstCharOptimizedIndices = firstCharOptimizedIndices;

--- a/main.ts
+++ b/main.ts
@@ -43,22 +43,25 @@ class AddLinkstoSVG implements IArgdownPlugin{
 			var nodes = response.map.nodes;
 
 			for (var node of nodes) {
-				var current_id = node.id;
-				//nx -> node(x+1)
-				var svg_id = "node" + (parseInt(current_id[1]) + 1);
-				var current_svg_element = doc.getElementById(svg_id);
 				if (!node.labelTextRanges) {
 					continue;
 				}
-				//only the first element will be used
-				var range = node.labelTextRanges[0];
-				if (range.type == 'obsidian-link') {
-					var text_title = current_svg_element.getElementsByTagName("text")[0];
-					text_title.innerHTML = `<a data-href="${range.text}" href="${range.text}" class="internal-link" target="_blank" rel="noopener">` +
-												text_title.innerHTML +
-											`</a>`;
-				}
+				var current_node_id = node.id;
+				//Creating the ID of the nodes according to the formula: 'nx' = 'node(x+1)'
+				var svg_id = "node" + (parseInt(current_node_id[1]) + 1);
+				var current_svg_element = doc.getElementById(svg_id);
 
+				//only the first obsidian link found will be used to wrap the title
+				for (var range of node.labelTextRanges) {
+					if (range.type == 'obsidian-link') {
+						//the first text element is the title
+						var text_title = current_svg_element.getElementsByTagName("text")[0];
+						text_title.innerHTML = `<a data-href="${range.text}" href="${range.text}" class="internal-link" target="_blank" rel="noopener">` +
+												text_title.innerHTML +
+												`</a>`;
+						break;	
+					}
+				}
 			}
 
 			response.svg = doc.documentElement.outerHTML;

--- a/main.ts
+++ b/main.ts
@@ -12,6 +12,8 @@ import "./mode/codemirror-argdown";
 import "./mode/codemirror-argdown.css";
 
 import {
+	IArgdownPlugin,
+	IRequestHandler,
 	ArgdownApplication,
 	IArgdownRequest,
 	ParserPlugin,
@@ -27,13 +29,42 @@ import {
 	PreselectionPlugin,
 	StatementSelectionPlugin,
 	ArgumentSelectionPlugin,
-	HtmlExportPlugin,
 	ExplodeArgumentsPlugin
 } from "./lib/argown-core";
 import {SyncDotToSvgExportPlugin } from "@argdown/core/dist/plugins/SyncDotToSvgExportPlugin"; // it needs to be exported explicitly
 
 import {argdownMapScript, webComponentStyle, webcomponentsBundle} from "webComponentScriptAndStyle";
 
+class AddLinkstoSVG implements IArgdownPlugin{
+        name: string = "AddLinkstoSVG";
+        run: IRequestHandler = (_request: Request, response: Response) => {
+			var parser = new DOMParser();
+			var doc = parser.parseFromString(response.svg, "image/svg+xml");
+			var nodes = response.map.nodes;
+
+			for (var node of nodes) {
+				var current_id = node.id;
+				//nx -> node(x+1)
+				var svg_id = "node" + (parseInt(current_id[1]) + 1);
+				var current_svg_element = doc.getElementById(svg_id);
+				if (!node.labelTextRanges) {
+					continue;
+				}
+				//only the first element will be used
+				var range = node.labelTextRanges[0];
+				if (range.type == 'obsidian-link') {
+					var text_title = current_svg_element.getElementsByTagName("text")[0];
+					text_title.innerHTML = `<a data-href="${range.text}" href="${range.text}" class="internal-link" target="_blank" rel="noopener">` +
+												text_title.innerHTML +
+											`</a>`;
+				}
+
+			}
+
+			response.svg = doc.documentElement.outerHTML;
+			return response;
+		}
+}
 
 interface MyPluginSettings {
 	initialView: string;
@@ -79,6 +110,7 @@ export default class MyPlugin extends Plugin {
 		el.innerHTML = `${argdownInputToComponent(source)}`;
 	}
 }
+
 
 /**
  *  Takes in argdown syntax and returns a web component with the map
@@ -129,6 +161,9 @@ function argdownInputToComponent(input: string) {
 	const highlightSourcePlugin = new HighlightSourcePlugin();
 	app.addPlugin(highlightSourcePlugin, "highlight-source");
 
+	const addLinkstoSVG = new AddLinkstoSVG();
+	app.addPlugin(addLinkstoSVG, "addLinksSVG");
+
 	const webComponentExportPlugin = new WebComponentExportPlugin({initialView: pluginSettings.initialView});
 	app.addPlugin(webComponentExportPlugin, "export-web-component");
 
@@ -149,10 +184,13 @@ function argdownInputToComponent(input: string) {
 			"export-dot",
 			"export-svg",
 			"highlight-source",
+			"addLinksSVG",
 			"export-web-component"
+
 		],
-		// logLevel: "verbose"
+		logLevel: "verbose"
 	}
+
 	return app.run(request).webComponent;
 }
 


### PR DESCRIPTION
Support for linking notes #10 
With this feature one obsidian link can be included for each node. The link will appear as the title of the node.

I added support for obsidian links in the parser and model plugin of argdown-core.js. Now obsidian links can be parsed and used by other plugins. Then I added plugin which modified the SVG data to wrap its first text element (which appears as the title) in an obsidian <a> tag.

Note: Only one obsidian link per argdown statement or argument is supported.